### PR TITLE
Write and organize Natspec comments

### DIFF
--- a/script/DeployMerkleAirdrop.s.sol
+++ b/script/DeployMerkleAirdrop.s.sol
@@ -7,11 +7,39 @@ import {BagelToken} from "../src/BagelToken.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {ZkSyncChainChecker} from "lib/foundry-devops/src/ZkSyncChainChecker.sol";
 
+/**
+ * @title DeployMerkleAirDrop
+ * @author Okhamena Azeez
+ * @notice A Foundry deployment script for the MerkleAirDrop system
+ * @dev Deploys BagelToken and MerkleAirDrop contracts, mints tokens and transfers them to the airdrop contract
+ */
 contract DeployMerkleAirDrop is Script {
+    /*//////////////////////////////////////////////////////////////
+                            STATE VARIABLES
+    //////////////////////////////////////////////////////////////*/
+    
+    /**
+     * @notice The Merkle root hash for the airdrop whitelist
+     * @dev This root is used to verify airdrop claims
+     */
     bytes32 public MERKLE_ROOT = bytes32(0xaa5d581231e596618465a56aa0f5870ba6e20785fe436d5bfb82b08662ccc7c4);
+    
+    /**
+     * @notice Total amount of tokens to transfer to the airdrop contract
+     * @dev Calculated as 4 users * 25 tokens * 1e18 (18 decimals)
+     */
     uint256 public constant AMOUNT_TO_TRANSFER = 4 * 25 * 1e18;
     
+    /*//////////////////////////////////////////////////////////////
+                            EXTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
 
+    /**
+     * @notice Main deployment function
+     * @dev Deploys BagelToken and MerkleAirDrop contracts, mints tokens and funds the airdrop
+     * @return bagelToken The deployed BagelToken contract instance
+     * @return merkleAirdrop The deployed MerkleAirDrop contract instance
+     */
     function run() external returns (BagelToken, MerkleAirDrop) { 
         vm.startBroadcast();
         BagelToken bagelToken = new BagelToken();

--- a/script/GenerateInput.s.sol
+++ b/script/GenerateInput.s.sol
@@ -5,14 +5,53 @@ import {Script} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
 
-// Merkle tree input file generator script
+/**
+ * @title GenerateInput
+ * @author Okhamena Azeez
+ * @notice A Foundry script that generates JSON input files for Merkle tree creation
+ * @dev Creates a structured JSON file with addresses and amounts for airdrop whitelist
+ */
 contract GenerateInput is Script {
+    /*//////////////////////////////////////////////////////////////
+                            STATE VARIABLES
+    //////////////////////////////////////////////////////////////*/
+    
+    /**
+     * @notice The amount of tokens each whitelisted address will receive
+     * @dev Set to 25 tokens with 18 decimal places
+     */
     uint256 private constant AMOUNT = 25 * 1e18;
+    
+    /**
+     * @notice Array defining the data types for the Merkle tree leaves
+     * @dev Contains "address" and "uint" types
+     */
     string[] types = new string[](2);
+    
+    /**
+     * @notice Counter for the number of whitelisted addresses
+     */
     uint256 count;
+    
+    /**
+     * @notice Array of whitelisted addresses for the airdrop
+     * @dev These addresses will be included in the Merkle tree
+     */
     string[] whitelist = new string[](4);
+    
+    /**
+     * @notice The file path where the generated JSON input will be saved
+     */
     string private constant INPUT_PATH = "/script/target/input.json";
 
+    /*//////////////////////////////////////////////////////////////
+                            PUBLIC FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Main execution function that generates the JSON input file
+     * @dev Sets up data types, whitelist addresses, creates JSON and writes to file
+     */
     function run() public {
         types[0] = "address";
         types[1] = "uint";
@@ -28,6 +67,15 @@ contract GenerateInput is Script {
         console.log("DONE: The output is found at %s", INPUT_PATH);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Creates a JSON string representation of the whitelist data
+     * @dev Formats the addresses and amounts into a structured JSON format
+     * @return A properly formatted JSON string containing all whitelist data
+     */
     function _createJSON() internal view returns (string memory) {
         string memory countString = vm.toString(count); // convert count to string
         string memory amountString = vm.toString(AMOUNT); // convert amount to string

--- a/script/SplitSignature.s.sol
+++ b/script/SplitSignature.s.sol
@@ -3,9 +3,34 @@ pragma solidity ^0.8.24;
 
 import { Script, console } from "forge-std/Script.sol";
 
+/**
+ * @title SplitSignature
+ * @author Okhamena Azeez
+ * @notice A Foundry script for splitting ECDSA signatures into their v, r, s components
+ * @dev This script reads a signature from a file and splits it into its cryptographic components
+ */
 contract SplitSignature is Script {
+    /*//////////////////////////////////////////////////////////////
+                               ERRORS
+    //////////////////////////////////////////////////////////////*/
+    
+    /**
+     * @notice Thrown when the signature length is not exactly 65 bytes
+     */
     error __SplitSignatureScript__InvalidSignatureLength();
 
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Splits an ECDSA signature into its v, r, s components
+     * @dev Uses inline assembly for efficient byte manipulation
+     * @param sig The signature bytes to split (must be 65 bytes)
+     * @return v The recovery id (1 byte)
+     * @return r The first 32 bytes of the signature
+     * @return s The second 32 bytes of the signature
+     */
     function splitSignature(bytes memory sig)
         internal
         pure
@@ -26,6 +51,14 @@ contract SplitSignature is Script {
         }
     }
 
+    /*//////////////////////////////////////////////////////////////
+                            EXTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Main execution function for the script
+     * @dev Reads signature from "signature.txt" file and logs the split components
+     */
     function run() external {
         string memory sig = vm.readFile("signature.txt");
         bytes memory sigBytes = vm.parseBytes(sig);


### PR DESCRIPTION
Add NatSpec documentation to all smart contracts in the `script` folder to improve code clarity and documentation generation.